### PR TITLE
Fix #62: shutdown agents after all -main methods

### DIFF
--- a/src/rdf4j/convert.clj
+++ b/src/rdf4j/convert.clj
@@ -65,4 +65,5 @@
           model (read-file-rdf-model source input)
           writer (make-stdout-rdf-writer output)]
       (log/debug "Model count: %d" (count model))
-      (Rio/write model writer))))
+      (Rio/write model writer))
+    (shutdown-agents)))

--- a/src/rdf4j/dump.clj
+++ b/src/rdf4j/dump.clj
@@ -105,4 +105,5 @@
     (cond
       (:h opts) (println banner)
       (:V opts) (println "Version: " version)
-      :else (do-dump opts))))
+      :else (do-dump opts))
+    (shutdown-agents)))

--- a/src/rdf4j/loader.clj
+++ b/src/rdf4j/loader.clj
@@ -134,4 +134,5 @@
     (cond
       (:h opts) (println banner)
       (:V opts) (println "Version: " rdf4j.version/version)
-      :else (do-loading opts))))
+      :else (do-loading opts))
+    (shutdown-agents)))


### PR DESCRIPTION
Fix #62 

- add `shutdon-agents` into all -main mehods
